### PR TITLE
isPrintingAvailable had a small bug

### DIFF
--- a/src/ios/PrintPlugin.m
+++ b/src/ios/PrintPlugin.m
@@ -25,9 +25,9 @@
  - (void) isPrintingAvailable:(CDVInvokedUrlCommand*)command{
     NSUInteger argc = [command.arguments count];
     
-    if (argc < 1) {
-        return;
-    }
+//    if (argc < 0) {
+//        return;
+//    }
     CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:([self isPrintServiceAvailable] ? YES : NO)];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }


### PR DESCRIPTION
isPrintingAvailable() was not working as expected.
The method returns since there are no args passed.
I don't know why exactly the arg count is checked. To get the expected result I commented the unwanted.

BTW thank you so much for the plugin. It helped us a lot and saved us time.