### PR TITLE
Fixed dependencies' package IDs

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -8,7 +8,7 @@
   <description>Cordova Print Plugin</description>
   <license>Apache 2.0</license>
   <keywords>cordova,PrintPlugin</keywords>
-  <dependency id="org.apache.cordova.device" url="https://github.com/apache/cordova-plugin-device.git" />
+  <dependency id="cordova-plugin-device" url="https://github.com/apache/cordova-plugin-device.git" />
   <dependency id="org.apache.cordova.inappbrowser" url="https://github.com/apache/cordova-plugin-inappbrowser.git" />
 
   <js-module src="www/PrintPlugin.js" name="PrintPlugin">

--- a/plugin.xml
+++ b/plugin.xml
@@ -8,7 +8,8 @@
   <description>Cordova Print Plugin</description>
   <license>Apache 2.0</license>
   <keywords>cordova,PrintPlugin</keywords>
-  <dependency id="org.apache.cordova.inappbrowser" url="https://github.com/apache/cordova-plugin-inappbrowser.git" />
+  <dependency id="cordova-plugin-device" url="https://github.com/apache/cordova-plugin-device.git" />
+  <dependency id="cordova-plugin-inappbrowser" url="https://github.com/apache/cordova-plugin-inappbrowser.git" />
 
   <js-module src="www/PrintPlugin.js" name="PrintPlugin">
     <clobbers target="window.PrintPlugin" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -11,9 +11,6 @@
   <dependency id="org.apache.cordova.device" url="https://github.com/apache/cordova-plugin-device.git" />
   <dependency id="org.apache.cordova.inappbrowser" url="https://github.com/apache/cordova-plugin-inappbrowser.git" />
 
-  <dependency id="org.apache.cordova.device" url="https://github.com/apache/cordova-plugin-device.git" />
-  <dependency id="org.apache.cordova.inappbrowser" url="https://github.com/apache/cordova-plugin-inappbrowser.git" />
-
   <js-module src="www/PrintPlugin.js" name="PrintPlugin">
     <clobbers target="window.PrintPlugin" />
   </js-module>

--- a/plugin.xml
+++ b/plugin.xml
@@ -8,7 +8,6 @@
   <description>Cordova Print Plugin</description>
   <license>Apache 2.0</license>
   <keywords>cordova,PrintPlugin</keywords>
-  <dependency id="cordova-plugin-device" url="https://github.com/apache/cordova-plugin-device.git" />
   <dependency id="org.apache.cordova.inappbrowser" url="https://github.com/apache/cordova-plugin-inappbrowser.git" />
 
   <js-module src="www/PrintPlugin.js" name="PrintPlugin">


### PR DESCRIPTION
I was getting errors when I initially tried to add your plugin via the Cordova CLI:

```
Failed to install 'com.badrit.PrintPlugin':Error: Expected plugin to have ID "org.apache.cordova.device" but got "cordova-plugin-device".
```

and:

```
Failed to install 'com.badrit.PrintPlugin':Error: Expected plugin to have ID "org.apache.cordova.inappbrowser" but got "cordova-plugin-inappbrowser".
```

I got rid of the duplicate dependency elements and changed the IDs to the expected IDs, now it adds the plugin successfully without errors.
